### PR TITLE
Expose Model and Msg

### DIFF
--- a/src/UIExplorer.elm
+++ b/src/UIExplorer.elm
@@ -4,6 +4,8 @@ module UIExplorer
         , renderStories
         , UI
         , UICategory
+        , Model
+        , Msg
         , addUICategory
         , emptyUICategories
         , createUI


### PR DESCRIPTION
Compiling project using this library results in a message:
```
main =
^^^^
I inferred the type annotation so you can copy it into your code:

main : Program Never UIExplorer.Model UIExplorer.Msg
```

However, it's not possible to fix the warning because UIExplorer.Model and UIExplorer.Msg are not exposed.

This PR fixes this issue by exposing them.