### PR TITLE
Fix url for elm package site

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ You can now run the `Main.elm` application with the tool of your choice.
 - **Categories :** Your UI Explorer can be divided into categories. Convenient if you have many views and you want to group them by family.
 
 
-- **Plugins :** Elm UI Explorer has a mechanism that let you extend the tool by creating your own plugins. By defaults the library comes with [built in plugins](src/UIExplorer/Plugins).
+- **Plugins :** Elm UI Explorer has a mechanism that let you extend the tool by creating your own plugins. By defaults the library comes with [built in plugins](https://github.com/kalutheo/elm-ui-explorer/tree/master/src/UIExplorer/Plugins).
 
 
 - **Customization :** You can make the header match your brand identity by changing colors, title and icons.


### PR DESCRIPTION
This link is broken in the elm package website because it was relative, not absolute.

Check the [link](https://package.elm-lang.org/packages/kalutheo/elm-ui-explorer/latest)