### PR TITLE
Make Note.viewEnhancer signature more generic

### DIFF
--- a/src/UIExplorer/Plugins/Note.elm
+++ b/src/UIExplorer/Plugins/Note.elm
@@ -40,7 +40,7 @@ import UIExplorer exposing (ViewEnhancer, explore, getCurrentSelectedStory)
 
 {-| This is the part that allows to display notes underneath the view
 -}
-viewEnhancer : ViewEnhancer {} () { a | note : String }
+viewEnhancer : ViewEnhancer a b { c | note : String }
 viewEnhancer model storiesView =
     let
         note =


### PR DESCRIPTION
Hey buddy, I was implementing a more complex component and I wanted to show some interaction, but then I'm not able to use the notes plugin anymore because the signature requires the models as `{}` and msg as `()`.

I was also wondering about maybe instead of using `a b c` for the generic types, we could use like `customModel msg pluginModel` or something like that in order to be more easy to understand what's going on inside the package :) 