### PR TITLE
Correct elm-feather constraints

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "1602/elm-feather": "1.0.0 <= v < 2.3.5",
+        "1602/elm-feather": "2.3.2 <= v < 2.3.5",
         "avh4/elm-debug-controls": "2.2.1 <= v < 3.0.0",
         "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",


### PR DESCRIPTION
The current version constraint of `1602/elm-feather` is too wide, as versions before 2.3.2 rely on elm < 0.19 and old package names as such `elm-lang/core`. From my understanding, these old versions would not be compatible with elm-ui-explorer. This has lead to an issue with erroneous package resolution in intellij-elm (an IDE plugin). 

See here for more info: https://github.com/klazuka/intellij-elm/issues/681