### PR TITLE
Add mime type to explorer.js import to avoid FF complaints

### DIFF
--- a/cli/src/templates/index.html.ejs
+++ b/cli/src/templates/index.html.ejs
@@ -14,7 +14,7 @@
 
   <body class="overflow-hidden">
     <div id="root"></div>
-    <script src="explorer.js"></script>
+    <script type="text/javascript" src="explorer.js"></script>
     <script type="text/javascript">
       var app = Elm.Explorer.init({
         node: document.getElementById("root")


### PR DESCRIPTION
Had a problem with firefox 88 about a potential wrong mime type and ignoring explorer.js