### PR TITLE
Apply same height styling to main content area

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -20,6 +20,7 @@
         "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
         "elm-explorations/markdown": "1.0.0 <= v < 2.0.0"
     },

--- a/examples/button/elm.json
+++ b/examples/button/elm.json
@@ -13,13 +13,13 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {
             "NoRedInk/datetimepicker-legacy": "1.0.4",
-            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",

--- a/examples/dsm/elm.json
+++ b/examples/dsm/elm.json
@@ -12,6 +12,7 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
@@ -20,7 +21,6 @@
             "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {
-            "elm/json": "1.1.3",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",

--- a/src/UIExplorer.elm
+++ b/src/UIExplorer.elm
@@ -76,8 +76,9 @@ import Browser
 import Browser.Navigation as Navigation
 import FeatherIcons
 import Html exposing (Html, a, article, aside, button, div, h3, header, img, li, span, text, ul)
-import Html.Attributes exposing (class, classList, href, src, style)
+import Html.Attributes exposing (class, classList, href, property, src, style)
 import Html.Events exposing (onClick)
+import Json.Encode as Encode
 import Maybe
 import UIExplorer.ColorMode exposing (ColorMode(..))
 import Url
@@ -1209,9 +1210,7 @@ view config model =
                     , "overflow-scroll"
                     , "main-content"
                     ]
-                , style
-                    "height"
-                    "calc(100vh - 86px) !important"
+                , property "style" (Encode.string "height: calc(100vh - 86px) !important")    
                 ]
                 [ viewContent config model ]
             ]

--- a/src/UIExplorer.elm
+++ b/src/UIExplorer.elm
@@ -1209,6 +1209,9 @@ view config model =
                     , "overflow-scroll"
                     , "main-content"
                     ]
+                , style
+                    "height"
+                    "calc(100vh - 86px) !important"
                 ]
                 [ viewContent config model ]
             ]


### PR DESCRIPTION
This height adjustment allows for missing overflow items to be
rendered on the associated div and allows scrolling to them.

Fixes #86